### PR TITLE
Suggested improvements for storage / file IO docs

### DIFF
--- a/reference/uxp/using-file-apis.md
+++ b/reference/uxp/using-file-apis.md
@@ -1,44 +1,51 @@
 # Using the File API
 
-The File API surface is intended to be a simple, cross-platform API surface that makes it easy to read and write text and binary files. Access to user files is user-mediated using file and folder pickers, but access to temporary files requires no user interaction. The File APIs themselves are asynchronous in nature, and so can be used with `Promise`s or `async`/`await`.
+XD provides a simple, cross-platform API surface that makes it easy to read and write text and binary files. Three key things to note:
+
+* Instead of working with string paths, you work with File and Folder objects.
+* Access to the user's files requires showing a file picker UI, but you can access temporary files and any files packaged inside your plugin without needing any user interaction. If you have a File/Folder object, then you have access to the corresponding item on disk.
+* File APIs are asynchronous, returning Promises which you can use with `then()` or the `async`/`await` keywords.
 
 ## Getting access to the local file system
 
-You can get access to the local file system APIs by using the following:
+Start using the file system APIs by obtaining a [FileSystemProvider](./module/storage.md#module-storage-filesystemprovider) object (shortened to `fs` in the code here):
 
 ```js
 const fs = require("uxp").storage.localFileSystem;
 ```
 
-Once you have `fs`, you can use it to request access to a temporary folder, the plugin's own folder, or to get access to user folders:
+You can use the `fs` object to access a temporary folder or your plugin's own folder immediately, or request access to user folders by showing a file picker:
 
 ```js
-const tempFolder = await fs.getTemporaryFolder(); // requires no user interaction
-const pluginFolder = await fs.getPluginFolder();  // this is a read-only folder containing the plugin's assets
-const pluginDataFolder = await fs.getDataFolder(); // this is a read-write persistent folder for the plugin, primarily for settings
-const userFolder = await fs.getFolder(); // this displays a folder picker
-const [aFile] = await fs.getFileForOpening(); // this display a file picker, suitable for reading contents
-const anotherFile = await fs.getFileForSaving("hello.txt"); // this displays a save file picker, suitable for writing contents
+// These require no user interaction:
+const tempFolder = await fs.getTemporaryFolder();
+const pluginFolder = await fs.getPluginFolder();  // read-only access to the plugin's install folder
+const pluginDataFolder = await fs.getDataFolder();  // folder to store settings
+
+// Display file/folder picker UI to access user files:
+const userFolder = await fs.getFolder();  // folder picker
+const aFile = await fs.getFileForOpening();  // "Open" file picker, suitable for reading contents
+const anotherFile = await fs.getFileForSaving("hello.txt");  // "Save" file picker, suitable for writing contents
 ```
 
-If you have a folder, you can use `getEntries` to request all the entries within a folder:
+If you have a [Folder](./module/storage.md#module-storage-folder), you can use [`getEntries()`](./module/storage.md#module-storage-folder-getentries) to enumerate the folder's contents:
 
 ```js
-const entries = await pluginFolder.getEntries();
-entries.map(entry => console.log(entry.name));
+const entries = await folder.getEntries();
+entries.forEach(entry => console.log(entry.name));
 ```
 
-You can read and write files like so:
+If you have a [File](./module/storage.md#module-storage-file), you can read and write its contents like so:
 
 ```js
 const contents = await aFile.read();
 await anotherFile.write(contents);
 ```
 
-You can create a file too:
+You can create new files inside a folder you have access to:
 
 ```js
-const newFile = await tempFolder.createEntry("tempfile.txt", {overwrite: true});
+const newFile = await folder.createEntry("examples.txt", {overwrite: true});
 newFile.write("Hello, world!");
 ```
 


### PR DESCRIPTION
- Suggested revamp of "using file APIs" intro doc
  - And add more links to the specific APIs mentioned there.
- Improve docs for filepicker APIs:
  - More explicitly discuss how dialog UI figures into `getFileForOpening()` /
    `getFileForSaving()` / `getFolder()`, and be crisper about cancelation
    behavior.
  - Explain that `types` has no "." in the file extension, is *required* for
    `getFileForSaving()`, and must match `defaultFileName`.
  - Link to `storage.domains` consts in docs for `initialDomain`.
  - Explain `getFileForOpening()`'s `allowMultiple` flag in more detail.
- Clarify behavior of `createEntry()` / `createFile()` / `createFolder()` - when
  is an item on disk created and when is the overwrite flag a factor. (And
  clarify how `getEntry()` differs).
  - Also clarify that `getEntry()` allows relative paths.
- Remove docs for Entry constructor and make it more clear you never manually
  construct Entry/File/Folder/provider or build your own fs provider impl.
- Remove docs for static method APIs since the class identifiers don't seem
  to be exposed (e.g. `storage.File` is undefined).
- Fix omitted first arg on `getFileForSaving()`.
- Fix example that treated `getFileForSaving()` as returning array.
- Add notes that more that one Entry object can exist for the same path on
  disk, and an Entry can exist when the item on disk does not.
- Add missing `await` in `getMetadata()` code example.
- Don't document `append` option for `write()` yet since it rarely works
  correctly right now (CCP-6117).
- Fix several typos using `=` instead of `:` in options objects
- Replace type docs saying "any" or "\*" with the slightly more precise "Object"
- Clarify how Entry objects are affected by move/rename/copy operations
- Remove smattering of "Access: public" notations which are redundant since
  everything in these docs is public.
- Fix broken links for storage.formats, storage.modes, storage.types members.
- Fix incorrect type for `url` property & tweak docs wording.
- Fix missing argument & add missing type docs for `getFsUrl()` & `getNativePath()`
- Clarify `getTemporaryFolder()`, `getDataFolder()`, `getPluginFolder()`, add type
  docs, and replace term "extension" with "plugin."
- Small improvements to code examples for binary file IO
- Fix bug in `getFolder()` example, treating an array as a single file.