### PR TITLE
Misc docs tweaks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,11 +30,23 @@ Security issues shouldn't be reported on this issue tracker. Instead, [file an i
 
 ## Gitbook Configuration
 
-### SUMMARY.MD
+The GitHub Pages rendering of this documentation is generated using [Gitbook](https://www.gitbook.com/). To preview this rendering locally:
 
-When adding documentation to this site, be sure to add the item to the correct location in `SUMMARY.MD`. Otherwise your content will not be rendered when the site is published.
+```bash
+npm install
+npm run book:install
+npm run book:build
 
-### Plugins in use
+# Now the generated Gitbook site is in a '_book' folder. It's best viewed from
+# http://localhost (not file://), so start a local web server, e.g.:
+http-server -c-1 _book
+```
+
+### Adding pages
+
+When adding an entirely new documentation page to this site, be sure to add the new file to the correct location in `SUMMARY.MD`. Otherwise your content will not be rendered when the site is published.
+
+### Gitbook plugins in use
 
 Plugin                            | For                                   | Link
 ---------------------------------:|:--------------------------------------|:-----------------------

--- a/Guides/how-to-ask-user-for-confirmation-guide/README_HTML.md
+++ b/Guides/how-to-ask-user-for-confirmation-guide/README_HTML.md
@@ -25,12 +25,9 @@ This sample demonstrates how to build a user confirmation dialog in XD using HTM
 
 ## Technology Used
 - References: 
-	- [UXP API - Document](https://adobe-xd.gitbook.io/plugin-api-reference/uxp-api-reference/dom5-apis/classes/document)
-	- [UXP API - Dialog](https://adobe-xd.gitbook.io/plugin-api-reference/uxp-api-reference/dom5-apis/html-elements/htmldialogelement)
-	- [UXP API - Form](https://adobe-xd.gitbook.io/plugin-api-reference/uxp-api-reference/dom5-apis/html-elements/htmlhtmlelement)
-	- [UXP API - Footer](https://adobe-xd.gitbook.io/plugin-api-reference/uxp-api-reference/dom5-apis/html-elements/htmlhtmlelement)
-	- [UXP API - Button](https://adobe-xd.gitbook.io/plugin-api-reference/uxp-api-reference/dom5-apis/html-elements/htmlbuttonelement)	
-	- [UXP API - Heading](https://adobe-xd.gitbook.io/plugin-api-reference/uxp-api-reference/dom5-apis/html-elements/htmlhtmlelement)
+	- [UXP API - Document](../reference/uxp/class/Document.md)
+	- [UXP API - Dialog](../reference/ui/dialogs.md)
+	- [UXP API - Button](../reference/ui/widgets/buttons.md)
 
 ## Prerequisites
 - Basic knowledge of HTML, CSS, and JavaScript.

--- a/Guides/how-to-package-a-plugin/README.md
+++ b/Guides/how-to-package-a-plugin/README.md
@@ -1,7 +1,7 @@
 # How to package a plugin.
 This guide describes how to package the files of an XD plugin.
 
-It is a prerequisite to have a working plugin with all the files that you intend to package. For reference, **this guide will use a sample plugin code [here](https://github.com/AdobeXD/Plugin-Samples/tree/master/getting-started)**.
+It is a prerequisite to have a working plugin with all the files that you intend to package. For reference, **this guide will use sample plugin code found [here](https://github.com/AdobeXD/Plugin-Samples/tree/master/getting-started)**.
 
 Please note the screenshots are from a mac machine but the steps would be identitical on a windows machine.
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -168,5 +168,3 @@
 ## Upcoming
 
 * [Plugin API Roadmap](./README.md)
-<!--* [XD CE API Roadmap](./README.md)-->
-* [XD Cloud Extensibility](./README.md)

--- a/changes.md
+++ b/changes.md
@@ -18,16 +18,15 @@ This release has UI polish and other finishing touches. It also comes with sever
 
 * If `application.createRenditions()` is passed bad arguments, the error string it throws now contains a much more useful message.
 * `createEntry()` will _not_ create a file on disk until you write to it.
-* You can now export renditions to any user-mediated location on UWP. Previously you needed to export to a temporary entry first, and then move it into the correct location.
 * Dialogs have received minor layout tweaks and polish.
 * Dialog buttons on Windows are in the correct location.
 * Dialogs can be wider on Windows than previous builds.
 * On Windows it's now possible to show multiple dialogs in sequence, like on macOS. Be sure to wait for the first dialog's promise to resolve before showing a second dialog.
 * Text fields are no longer limited to 150 characters.
-- When upgrading or downgrading plugins, the plugin folder is now recursively deleted. This will no longer cause an error when attempting an installation. (XD-59699)
+- When upgrading or downgrading plugins, the plugin folder is now recursively deleted. This will no longer cause an error when attempting an installation.
 - Images within dialogs now render while the dialog is animating (macOS only).
-- Dialogs on UWP now will expand or shrink appropriately to fit the content.
-- On UWP, showing multiple dialogs in sequence should no longer result in a crash.
+- Dialogs on Windows now will expand or shrink appropriately to fit the content.
+- On Windows, showing multiple dialogs in sequence should no longer result in a crash.
 - Tab order is now working correctly on macOS.
 - Secure Websockets are now supported.
 - When launching XD, plugin data that is orphaned (that is, a corresponding plugin isn't installed) will no longer be deleted. In the past, This could cause unexpected loss of preferences or data.
@@ -100,11 +99,11 @@ The following has changed in this release.
 
 * The File I/O APIs have moved to a new module. Use `require("uxp").storage.localFileSystem` to get access to the local file system provider.
 * Your plugins must now use the typical `module.exports` form to return commands. Instead of using `return`, just replace it with `module.exports = `.
-* If you want to render any UI controls in your plugins, you will need to be on macOS 10.12 or better (or UWP).
+* If you want to render any UI controls in your plugins, you will need to be on macOS 10.12 or better (or Windows).
 
 ### Export Renditions
 
-For an example of using export renditions, [see this guide](https://adobe-xd.gitbook.io/plugin-guides/working-with-content/how-to-generate-an-export-rendition-guide).
+For an example of using export renditions, [see this guide](./Guides/how-to-generate-an-export-rendition-guide).
 
 ### File I/O Improvements
 
@@ -173,7 +172,7 @@ The following has changed in this release.
 
 ### Networking APIs
 
-Networking APIs now work correctly on Windows (UWP).
+Networking APIs now work correctly on Windows.
 
 ### Asynchronous Scenegraph Access
 

--- a/known-issues.md
+++ b/known-issues.md
@@ -3,7 +3,7 @@
 ## General Issues
 
 - Developer/Side-loading Specific
-  - Plugin menus and handlers may not be in-sync across documents during development (XD-50283)
+  - Plugin menus and handlers may not be in-sync across documents during development
     - If someone modifies a plugin's files on disk while XD is running, and then opens more windows in XD, any windows that were open before reflect the old version of the plugin while windows that were opened later reflect the new version of the plugin. The menu bar will always reflect the old version of the plugin regardless of which window is current.
 
 ## Export Renditions
@@ -11,13 +11,17 @@
 - On Windows 10, exporting a rendition may cause XD to crash. This will be fixed in the next drop.
 - On Windows 10, exporting to a file or folder entry picked from a file picker will fail. You can work around this issue by writing those files first to a temporary folder or to the plugin's data folder. Then you can move them to the desired location.
 
+## Plugin Management
+
+- If Plugin Manager is open when you invoke Reload Plugins, it will not reflect any changes to the manifest (plugin name, description, icon) until you close & reopen it.
 
 ## Scenegraph
 
+- `Rectangle.cornerRadii` reports incorrect values if the corners are not all the same radius. Use `effectiveCornerRadii` instead to get accurate values.
 - It is possible to set nodes to 0 width or 0 height.
   - Scenenode setters block negative size values but allow 0 size, even though in many cases it is equally nonsensical. We do block 0 size in the UI.
   - In the past, XD's renderer would fail asserts (possibly even crash) with 0-size objects. I couldn't repro that any more, but unless we're covering it well as an officially supported case, it could easily regress again. There are some other minor bugs though, e.g. sharing fails if you have any 0-width/height artboards and bitmap export fails if any of the top-level items you're trying to export are 0-width/height.
-- Plugin command names in UWP Plugin menus are truncated (XD-52356, UWP Only)
+- Longer plugin command names may be truncated in the menu on Windows
   - Workaround: keep your plugin command names short!
 
 ## User Interface
@@ -39,14 +43,14 @@
 - `<option>` tags *must* have a `value` attribute, or referencing the `select`'s `value` property will return `undefined`.
 - `<select value="…"/>` does not show the value as selected. Instead, get a reference to the element and call `setAttribute("value", …)`.
 - If you don’t specify a width for your `form`, block elements inside may not take up the entire width. Workaround: always set a width for your `form` elements.
-- `form`s only support `method="dialog"`. They do not submit to endpoints automatically.
+- `form`s only support `method="dialog"`. They do not submit to a URL automatically.
 - It is not currently possible to specify the tab order.
 - The size of a `<textarea>` cannot be set with `rows` or `cols`. Use CSS styles `height` and `width` respectively.
 - `<input type="radio"/>` is not currently supported.
 - `<progress>` is not currently supported.
 - HTML5 input validation is not supported.
 - Images that fail to load will not render any “broken icon” image in place.
-- The `<dialog>` background color is different on UWP and macOS. On macOS, it is `#F5F5F5`, and on UWP it is `#FFFFFF`.
+- The `<dialog>` background color is different on Windows and macOS. On macOS, it is `#F5F5F5`, and on Windows it is `#FFFFFF`.
 - Input widgets do not accept `defaultValue`.
 - `<input type="password" />` is not supported.
 - `<option>` tags do not support `selected` or `disabled` attributes.

--- a/reference/ImageFill.md
+++ b/reference/ImageFill.md
@@ -35,7 +35,7 @@ selection.items[0].fill = fill;
 
 | Param | Type | Description |
 | --- | --- | --- |
-| fileOrDataURI | <code>!uxp.storage.File|string</code> | File object pointing to an image file; or a string containing a `data:` URI with a base-64 encoded image. |
+| fileOrDataURI | `!uxp.storage.File` or `string` | File object pointing to an image file; or a string containing a `data:` URI with a base-64 encoded image. |
 
 
 * * *

--- a/reference/application.md
+++ b/reference/application.md
@@ -43,6 +43,10 @@ console.log("OS locale:", application.systemLocale); // e.g. "en_US"
 ### application.createRenditions(renditions)
 Generate renditions of nodes in the document in a batch. Overwrites any existing files without warning.
 
+A single `createRenditions()` call can generate any number of renditions, including multiple renditions of the same node (with
+different output settings) or renditions of multiple different nodes. Only one `createRenditions()` call can be executing at any
+given time, so wait for the Promise it returns before calling it again.
+
 **Kind**: static method of [<code>application</code>](#module_application)  
 **Returns**: `Promise<Array<RenditionResult>, string>` -  Promise which is fulfilled with an array of RenditionResults (pointing to
 the same `outputFile`s that were originally passed in, or rejected with an error string if one or more renditions failed for
@@ -58,7 +62,7 @@ _All rendition settings fields are required_ (for a given rendition type) unless
 
 | Property | Type | Description |
 | --- | --- | --- |
-| node | !SceneNode | Root of scenegraph subtree to render |
+| node | !SceneNode | Root of scenegraph subtree to render. This may be _any_ node in the scenegraph, regardless of the current edit context. |
 | outputFile | !uxp.storage.File | File to save the rendition to (overwritten without warning if it already exists) |
 | type | string | File type: RenditionType.PNG, JPG, PDF, or SVG |
 | scale | number | _(PNG & JPG renditions)_ DPI multipler in the range [0.1, 100], e.g. 2.0 for @2x DPI. |

--- a/reference/structure/handlers.md
+++ b/reference/structure/handlers.md
@@ -5,7 +5,7 @@ All plugins must have a `main.js` file, which serves as the entry point for exec
 
 ## Wiring your code to the manifest
 
-Your `main.js` file returns a map linking each `commandId` from the manifest to a _handler function_ in your code:
+Your `main.js` file exports a map linking each `commandId` from the manifest to a _handler function_ in your code:
 
 ```js
 function sayHello(selection, documentRoot) {

--- a/reference/structure/manifest.md
+++ b/reference/structure/manifest.md
@@ -12,12 +12,12 @@ The manifest is where you include metadata about your plugin. Simply put, the ma
 
     "description": "Description of your plugin.",
     "icons": [
-        { "width": 96, "height": 96, "path": "images/icon.png" }
+        { "width": 96, "height": 96, "path": "images/icon@2x.png" }
     ],
 
     "host": {
         "app": "XD",
-        "minVersion": "13.0.11"
+        "minVersion": "13.0"
     },
 
     "uiEntryPoints": [

--- a/reference/ui/dialogs/showing.md
+++ b/reference/ui/dialogs/showing.md
@@ -14,9 +14,4 @@ dialog.showModal()
 >
 > The dialog element _must_ be present in the DOM before showing it. If it isn't, the method will throw an exception.
 
-It's important to note that you can only show one dialog at once. You should always close or dismiss a dialog first before showing another one.
-
-> **Danger**
->
-> On UWP (Windows 10), you may encounter difficulties rendering multiple dialogs in sequence. In general you should avoid doing so unless you're trying to render an experience that's substantially different from what came before. In that case, you may find it useful to insert a delay after one dialog closes before opening another.
-> (BUG: CCP-5854)
+It's important to note that you can only show one dialog at once. You should always close or dismiss a dialog first and then _wait for the dialog's promise to resolve_ before showing another one.

--- a/reference/ui/widgets/buttons.md
+++ b/reference/ui/widgets/buttons.md
@@ -193,7 +193,7 @@ As you can see, buttons are, by default rendered in _block_ layout. This results
 
 The remainder of the buttons are rendered in flex containers (see [Flexbox layout](../layout/flex.md)). When rendered within flex containers, buttons will respect the stretching and positioning, but by default buttons will shrink to fit their textual content.
 
-If you need a specific width, you can assign a `width` style, but it is important to be aware that widgets render with different metrics on macOS and UWP.
+If you need a specific width, you can assign a `width` style, but it is important to be aware that widgets render with different metrics on macOS and Windows.
 
 ## Guidelines
 


### PR DESCRIPTION
- Add CONTRIBUTING docs on how to run Gitbook to generate finished HTML
- Fix links that were still pointing to old adobe-xd.gitbook.io site
- Replace mentions of "UWP" with "Windows"
- Remove references to internal issue numbers
- Fix table formatting in ImageFill docs
- Add a few more known issues & don't say Windows renditions are 100% fixed
  in XD13 prerelease yet.
- Expand docs on renditions API a bit
- Remove outdated reference to Windows dialog-chaining issue.
- Tweak manifest sample to make it more clear icon is 2x DPI, and to show the
  preferred, less precise way of specifying min-required XD version number.
- Change docs on how command handlers are exposed to say "exports" instead
  of "returns"
