### PR TITLE
Fix of a small typo in the dialog dismissal page

### DIFF
--- a/reference/ui/dialogs/dismissal.md
+++ b/reference/ui/dialogs/dismissal.md
@@ -24,7 +24,7 @@ const okButton = document.querySelector("#ok");
 okButton.addEventListener("click", e => {
     onsubmit();
     e.preventDefault();
-}
+});
 ```
 
 You can listen for the dialog's dismissal using the `close` event on the dialog:


### PR DESCRIPTION
A `);` was missing in line 27, which gets fixed with this PR (in fact, it was a typo in the code meaning copying and pasting didn't work).

# Submit a pull request

## CLA

- [x] I have signed the [Adobe CLA](http://adobe.github.io/cla.html) (required).

## Topic

This is a pull request for:

- [x] A tutorial contained within this repo.
- [ ] A sample contained within this repo.
- [ ] Something new that I have already discussed with Adobe in a GitHub issue. Issue link:

## Versions

- [ ] XD version(s) tested :
- [ ] Tested XD version(s):

## Description of the pull request
Fixed a small type...