### PR TITLE
fix typo in ui-index.md

### DIFF
--- a/tutorials/ui-index.md
+++ b/tutorials/ui-index.md
@@ -1,6 +1,6 @@
 # Building user interfaces
 
-While plenty of XD plugins are perfectly suited to run like headless scripts, many plugins will need to interact witht the user in some way. XD plugins can display UI in the form of modal dialogs, built with JavaScript and a supported subset of HTML and CSS. For simple alerts and messages, we've also built various helpers which make it easy to display important messages, get user feedback, and more. The tutorials in this section will focus on the UI you can generate using these helpers. Should you need more power than these helpers provide, you can learn more by reading the [User Interface Concepts](/reference/ui/).
+While plenty of XD plugins are perfectly suited to run like headless scripts, many plugins will need to interact with the user in some way. XD plugins can display UI in the form of modal dialogs, built with JavaScript and a supported subset of HTML and CSS. For simple alerts and messages, we've also built various helpers which make it easy to display important messages, get user feedback, and more. The tutorials in this section will focus on the UI you can generate using these helpers. Should you need more power than these helpers provide, you can learn more by reading the [User Interface Concepts](/reference/ui/).
 
 The tutorials contained in this section will get you on your way to building plugin UI well-suited for XD utilizing the [Plugin Toolkit](https://github.com/AdobeXD/plugin-toolkit) library. Before continuing, please ensure that you install the tooklit in your project, as follows:
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] have signed the [Adobe CLA](http://adobe.github.io/cla.html) (required).

## Topic

This is a pull request for:

- [x] A tutorial contained within this repo.
- [ ] A sample contained within this repo.
- [ ] Something new that I have already discussed with Adobe in a GitHub issue. Issue link:

## Versions

- [ ] XD version(s) tested :
- [ ] Tested XD version(s):

## Description of the pull request

- Fixing a one word typo from `witht` to `with`
- Fixes issue #167
