### PR TITLE
Fixed wrong keyboard shortcut for reloading plugins on windows

### DIFF
--- a/tutorials/debugging/index.md
+++ b/tutorials/debugging/index.md
@@ -27,7 +27,7 @@ There's also a handy keyboard shortcut:
 | Platform      | Keyboard shortcut  |
 | ------------- | -------------      |
 | macOS         | Shift-Cmd-R        |
-| Windows       | Ctrl-Alt-E         |
+| Windows       | Ctrl-Shift-R       |
 
 If there are any errors blocking the plugin from loading, they will appear in the developer console on reload:
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Adobe CLA](http://adobe.github.io/cla.html) (required).

## Topic

This is a pull request for:

- [x] A tutorial contained within this repo.
- [ ] A sample contained within this repo.
- [ ] Something new that I have already discussed with Adobe in a GitHub issue. Issue link:

## Versions

- [x] XD version(s) tested : 16
- [x] Tested XD version(s): 16? (what's the difference to the line above?)

## Description of the pull request
Fixed a wrong keyboard shortcut for reloading plugins on Windows.

Fixes #176 