### PR TITLE
docs(ui-html): fix obvious typos in tag names

### DIFF
--- a/reference/uxp/ui-html-index.md
+++ b/reference/uxp/ui-html-index.md
@@ -34,12 +34,12 @@ elements  ||||
          |button| `uxp-variant="action"`             | Block  | Action Button
          |button| `uxp-selected="true"`              | Block  | Selected Action Button
          |button| `uxp-quiet="true"`                 | Block  | Quiet variation (except call to action)
-         |input]| [type="checkbox"](#input-checkbox) | Block  | Checkbox
-         |input]| [type="image"](#input-image)       | Block  | Image Button
-         |input]| [type="number"](#input-number)     | Block  | Text field
-         |input]| [type="range"](#input-range)       | Block  | Slider
-         |input]| [type="text"](#input-text)         | Block  | Text field
-         |input]| `type="text"` `uxp-quiet="true"`   | Block  | Quiet text field
+         |input| [type="checkbox"](#input-checkbox) | Block  | Checkbox
+         |input| [type="image"](#input-image)       | Block  | Image Button
+         |input| [type="number"](#input-number)     | Block  | Text field
+         |input| [type="range"](#input-range)       | Block  | Slider
+         |input| [type="text"](#input-text)         | Block  | Text field
+         |input| `type="text"` `uxp-quiet="true"`   | Block  | Quiet text field
          |select|                                    | Block  | Dropdown
          |option|                                    | N/A    | Dropdown options
          |textarea|                                    | Block  | Standard text area


### PR DESCRIPTION
- [x] I have signed the [Adobe CLA](http://adobe.github.io/cla.html) (required).

## Topic
n/a

## Versions
n/a

## Description of the pull request

This fixes obvious typos in html tags dicsussed in the doc.

Thanks