### PR TITLE
Fixes 404 in Quick Start tutorial 

### DIFF
--- a/tutorials/quick-start/index.md
+++ b/tutorials/quick-start/index.md
@@ -134,7 +134,7 @@ module.exports = {
 
 This code does the following:
 
-1.  Gets references to the `Rectangle` and `Color` classes from XD’s `scenegraph` module. There are several different [API modules you can load using `require()`](/reference/core/apis.html).
+1.  Gets references to the `Rectangle` and `Color` classes from XD’s `scenegraph` module. There are several different [API modules you can load using `require()`](/reference/core/apis.md).
 2.  Defines our handler function. The handler function will run when the user selects the _Plugins > Create Rectangle_ menu item.
 3.  Creates a new `Rectangle` object with width, height, and color properties.
 4.  Adds the `Rectangle` object to the scenegraph at the top-left (coordinates `0, 0`).


### PR DESCRIPTION
## CLA

- [x] I have signed the [Adobe CLA](http://adobe.github.io/cla.html) (required).

## Topic

This is a pull request for:

- [x] A tutorial contained within this repo.
- [ ] A sample contained within this repo.
- [ ] Something new that I have already discussed with Adobe in a GitHub issue. Issue link:

## Description 

This PR fixes the URL of the API modules link in Section 4 of the Quick Start.