### PR TITLE
Fix TypeError in network request tutorial sample code

### DIFF
--- a/tutorials/how-to-make-network-requests/index.md
+++ b/tutorials/how-to-make-network-requests/index.md
@@ -130,7 +130,7 @@ async function downloadImage(selection, jsonResponse) {                         
         const photoObj = await xhrBinary(photoUrl);                                // [3]
         const tempFolder = await fs.getTemporaryFolder();                          // [4]
         const tempFile = await tempFolder.createFile("tmp", { overwrite: true });  // [5]
-        await tempFile.write(photoObj, { format: uxp.formats.binary });            // [6]
+        await tempFile.write(photoObj, { format: uxp.storage.formats.binary });    // [6]
         applyImagefill(selection, tempFile);                                       // [7]
     } catch (err) {
         console.log("error")


### PR DESCRIPTION
## CLA

- [x] I have signed the [Adobe CLA](http://adobe.github.io/cla.html) (required).

## Topic

This is a pull request for:

- [x] A tutorial contained within this repo.
- [ ] A sample contained within this repo.
- [ ] Something new that I have already discussed with Adobe in a GitHub issue. Issue link:

## Versions

- [ ] XD version(s) tested : 27
- [ ] Tested XD version(s): 27

## Description of the pull request
The sample code in Step 5 of the tutorial throws a `TypeError:  Cannot read property 'binary' of undefined` when attempting to execute the `applyImage` command. This PR updates the parameters  in the tutorial per [the linked source code](https://github.com/AdobeXD/plugin-samples/blob/6e9c02dae98503b798f65977a43769688c01cb98/how-to-make-network-requests/main.js#L26):
>  await tempFile.write(photoObj, { format: uxp.storage.formats.binary });

I think this might help explain the happy coincidence scenario over in https://forums.adobexdplatform.com/t/uxp-is-not-defined/1575/4 as well?