### PR TITLE
feat(header): Add banner informing about new docs at adobe.io

### DIFF
--- a/public/custom.css
+++ b/public/custom.css
@@ -1,7 +1,7 @@
 @import url("https://fonts.googleapis.com/css?family=Roboto:200,300,400,700");
 
 .book {
-    height: calc(100% - 128px);
+    height: calc(100% - 180px);
 }
 
 .page-inner {

--- a/public/header.html
+++ b/public/header.html
@@ -117,7 +117,7 @@
 
 <header class="alert alert-warning hints-alert" style="margin: 0">
   <div class="hints-container">
-    This documentation is outdated. For the new documentation, please head over to <a href="https://adobe.io/xd/uxp">adobe.io</a>.
+    This XD Plugin documentation is out of date. Find updated documentation on <a href="https://adobe.io/xd/uxp">Adobe.io</a>.
   </div>
 </header>
 <!-- <div class="divider">

--- a/public/header.html
+++ b/public/header.html
@@ -117,7 +117,7 @@
 
 <header class="alert alert-warning hints-alert" style="margin: 0">
   <div class="hints-container">
-    This XD Plugin documentation is out of date. Find updated documentation on <a href="https://adobe.io/xd/uxp">Adobe.io</a>.
+    This XD Plugin documentation is out of date. Find updated documentation on <a href="http://adobe.com/go/xd-plugin-api-docs-from-legacy">Adobe.io</a>.
   </div>
 </header>
 <!-- <div class="divider">

--- a/public/header.html
+++ b/public/header.html
@@ -114,6 +114,12 @@
 <button type="button" class="console-btn coral-btn coral-btn-cta"> Adobe Developer Console</button>
 </a> -->
 </header>
+
+<header class="alert alert-warning hints-alert" style="margin: 0">
+  <div class="hints-container">
+    This documentation is outdated. For the new documentation, please head over to <a href="https://adobe.io/xd/uxp">adobe.io</a>.
+  </div>
+</header>
 <!-- <div class="divider">
 <p class="divider-text">Community and Support</p>
 </div> -->


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Adobe CLA](http://adobe.github.io/cla.html) (required).

## Topic

This is a pull request for:

_The "theme" / overall page structure_

- [ ] A tutorial contained within this repo.
- [ ] A sample contained within this repo.
- [ ] Something new that I have already discussed with Adobe in a GitHub issue. Issue link:

## Versions

- [ ] XD version(s) tested : n/a
- [ ] Tested XD version(s): n/a

## Description of the pull request
This adds a "warning banner" linking readers to the (relatively) new adobe.io-based documentation (specifically: https://adobe.io/xd/uxp), since there was previously no "obvious" way for developers to find out about the new site when visiting the docs page directly (e.g., via their bookmarks or a search engine):

![localhost_4000_](https://user-images.githubusercontent.com/25147704/127050154-6c032da0-a63e-40c6-9848-3e24dd9bd35c.png)

Please note that the missing XD logo in the header has nothing to do with the changes of this PR and appear to be an artifact of local testing.

I have, for now, kept the message rather "direct" and not too "diplomatic", but please just ping me if I should adjust the messaging a bit.

_This was built and tested using NodeJS v10, since gitbook doesn't appear to play nicely with newer versions._

Code-wise, this isn't the prettiest thing I've ever developed, but since this repo is basically abandoned (in favour of the new docs), I didn't want to put too much effort into it. If, however, we need anything fancier, just let me know and I'll adjust it accordingly (having worked as a web dev for the past 5.5 years has to be worth something, after all 😜 ).

Possible next steps after this PR (I'd like to keep this PR as small as possible to quickly get it merged) might include

- adding this message to the repo itself, as well (e.g., in the description or the `README.md`
- consider if it is worth the effort to add direct links to equivalent pages in the new documentation