### PR TITLE
Corrected API documentation for Entry.copyTo()

### DIFF
--- a/reference/uxp/module/storage.md
+++ b/reference/uxp/module/storage.md
@@ -238,6 +238,7 @@ original item - it is _not_ updated to reference the copy.
 | folder | `Folder` |  | the folder to which to copy this entry |
 | options | `\*` |  |  |
 | [options.overwrite] | `boolean` | <code>false</code> | if `true`, allows overwriting existing entries |
+| [options.allowFolderCopy] | `boolean` | <code>false</code> if `true`, allows copying the folder. |
 
 **Example**
 ```js
@@ -249,7 +250,7 @@ await someFile.copyTo(someFolder, {overwrite: true});
 ```
 **Example**
 ```js
-await someFolder.copyTo(anotherFolder, {overwrite: true});
+await someFolder.copyTo(anotherFolder, {overwrite: true, allowFolderCopy: true});
 ```
 
 <a name="module-storage-entry-moveto" id="module-storage-entry-moveto"></a>

--- a/reference/uxp/module/storage.md
+++ b/reference/uxp/module/storage.md
@@ -238,7 +238,7 @@ original item - it is _not_ updated to reference the copy.
 | folder | `Folder` |  | the folder to which to copy this entry |
 | options | `\*` |  |  |
 | [options.overwrite] | `boolean` | <code>false</code> | if `true`, allows overwriting existing entries |
-| [options.allowFolderCopy] | `boolean` | <code>false</code> if `true`, allows copying the folder. |
+| [options.allowFolderCopy] | `boolean` | <code>false</code> if `true`, allows copying the folder |
 
 **Example**
 ```js


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Adobe CLA](http://adobe.github.io/cla.html) (required).

## Topic

This is a pull request for:

- [x] A tutorial contained within this repo.
- [ ] A sample contained within this repo.
- [ ] Something new that I have already discussed with Adobe in a GitHub issue. Issue link:

## Versions

- [x] XD version(s) tested : 49
- [ ] Tested XD version(s):

## Description of the pull request

A correction in Entry.copyTo() UXP API.
